### PR TITLE
Use os.path.splitext to fix filename-extension splitting for extensions that aren't exactly 3 chars long

### DIFF
--- a/diarize.py
+++ b/diarize.py
@@ -65,7 +65,10 @@ if args.stemming:
         vocal_target = args.audio
     else:
         vocal_target = os.path.join(
-            "temp_outputs", "htdemucs", os.path.basename(args.audio[:-4]), "vocals.wav"
+            "temp_outputs",
+            "htdemucs",
+            os.path.splitext(os.path.basename(args.audio))[0],
+            "vocals.wav",
         )
 else:
     vocal_target = args.audio
@@ -180,10 +183,10 @@ else:
 
 ssm = get_sentences_speaker_mapping(wsm, speaker_ts)
 
-with open(f"{args.audio[:-4]}.txt", "w", encoding="utf-8-sig") as f:
+with open(f"{os.path.splitext(args.audio)[0]}.txt", "w", encoding="utf-8-sig") as f:
     get_speaker_aware_transcript(ssm, f)
 
-with open(f"{args.audio[:-4]}.srt", "w", encoding="utf-8-sig") as srt:
+with open(f"{os.path.splitext(args.audio)[0]}.srt", "w", encoding="utf-8-sig") as srt:
     write_srt(ssm, srt)
 
 cleanup(temp_path)

--- a/diarize_parallel.py
+++ b/diarize_parallel.py
@@ -64,7 +64,10 @@ if args.stemming:
         vocal_target = args.audio
     else:
         vocal_target = os.path.join(
-            "temp_outputs", "htdemucs", os.path.basename(args.audio[:-4]), "vocals.wav"
+            "temp_outputs",
+            "htdemucs",
+            os.path.splitext(os.path.basename(args.audio))[0],
+            "vocals.wav",
         )
 else:
     vocal_target = args.audio
@@ -170,10 +173,10 @@ else:
 
 ssm = get_sentences_speaker_mapping(wsm, speaker_ts)
 
-with open(f"{args.audio[:-4]}.txt", "w", encoding="utf-8-sig") as f:
+with open(f"{os.path.splitext(args.audio)[0]}.txt", "w", encoding="utf-8-sig") as f:
     get_speaker_aware_transcript(ssm, f)
 
-with open(f"{args.audio[:-4]}.srt", "w", encoding="utf-8-sig") as srt:
+with open(f"{os.path.splitext(args.audio)[0]}.srt", "w", encoding="utf-8-sig") as srt:
     write_srt(ssm, srt)
 
 cleanup(temp_path)


### PR DESCRIPTION
Currently filenames and extensions are split by simply cutting off the final four characters: `audio.wav -> [audio][.wav]`

That works great if you have a three character extension, but causes problems otherwise. For example if you're trying to diarise a .opus file (like I was), demucs will split the filename correctly, but diarize.py will split `audio.opus -> [audio.][opus]` and go looking for `temp_outputs/htdemucs/audio./vocals.wav`, which won't exist! This was slightly frustrating to figure out :)

Python's stdlib has a built in function `os.path.splitext` for doing this robustly, and I make here a pull request suggesting the simplest change.