### PR TITLE
Resolve .txt output file edge cases

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -237,10 +237,6 @@ def get_sentences_speaker_mapping(word_speaker_mapping, spk_ts):
 
 
 def get_speaker_aware_transcript(sentences_speaker_mapping, f):
-    # Make sure mapping list isn't empty
-    if not sentences_speaker_mapping:
-        return
-
     previous_speaker = sentences_speaker_mapping[0]["speaker"]
     f.write(f"{previous_speaker}: ")
 
@@ -254,7 +250,7 @@ def get_speaker_aware_transcript(sentences_speaker_mapping, f):
             previous_speaker = speaker
 
         # No matter what, write the current sentence
-        f.write(sentence)
+        f.write(sentence + " ")
 
 
 def format_timestamp(

--- a/helpers.py
+++ b/helpers.py
@@ -237,19 +237,24 @@ def get_sentences_speaker_mapping(word_speaker_mapping, spk_ts):
 
 
 def get_speaker_aware_transcript(sentences_speaker_mapping, f):
-    previous_speaker = sentences_speaker_mapping[0]["speaker"]
-    text = sentences_speaker_mapping[0]["text"]
+    # Make sure mapping list isn't empty
+    if not sentences_speaker_mapping:
+        return
 
-    for sentence_dict in sentences_speaker_mapping[1:]:
-        sp = sentence_dict["speaker"]
+    previous_speaker = sentences_speaker_mapping[0]["speaker"]
+    f.write(f"{previous_speaker}: ")
+
+    for sentence_dict in sentences_speaker_mapping:
+        speaker = sentence_dict["speaker"]
         sentence = sentence_dict["text"]
 
-        if sp != previous_speaker:
-            f.write(f"{previous_speaker}: {text}\n\n")
-            text = sentence
-            previous_speaker = sp
-        else:
-            text += " " + sentence
+        # If this speaker doesn't match the previous one, start a new paragraph
+        if speaker != previous_speaker:
+            f.write(f"\n\n{speaker}: ")
+            previous_speaker = speaker
+
+        # No matter what, write the current sentence
+        f.write(sentence)
 
 
 def format_timestamp(


### PR DESCRIPTION
## Problem

The code in `get_speaker_aware_transcript(...)` that writes the `.txt` output yields strange behavior in the edge case where there is only 1 identified speaker in the input audio file. Obviously it's silly to do diarization on an audio file with only 1 speaker, but in production, I can't trust my users not to do so. 

The existing logic builds up a text string per-speaker, then writes it when the speaker changes. If the speaker never changes (i.e., every dict in the list has the same speaker), nothing is ever written to the file, resulting in an empty output.

## Steps to reproduce

I was producing this behavior with [this audio file](https://www.flatworldsolutions.com/transcription/samples/Monologue.ogg), but it should be the result of any audio file with a single identified speaker.

## Solution

Instead of accumulating a paragraph then writing it to the file when the speaker changes, simply write each sentence in the loop step, and prepend a new paragraph start when the speaker changes.