### PR TITLE
Add initial prompt argument support

### DIFF
--- a/diarize.py
+++ b/diarize.py
@@ -65,6 +65,13 @@ parser.add_argument(
     help="if you have a GPU use 'cuda', otherwise 'cpu'",
 )
 
+parser.add_argument(
+    "--prompt",
+    dest="prompt",
+    default="",
+    help="Initial prompt for transcription",
+)
+
 args = parser.parse_args()
 
 if args.stemming:
@@ -102,6 +109,7 @@ if args.batch_size != 0:
         mtypes[args.device],
         args.suppress_numerals,
         args.device,
+        args.prompt,
     )
 else:
     from transcription_helpers import transcribe
@@ -113,6 +121,7 @@ else:
         mtypes[args.device],
         args.suppress_numerals,
         args.device,
+        args.prompt,
     )
 
 if language in wav2vec2_langs:

--- a/diarize_parallel.py
+++ b/diarize_parallel.py
@@ -64,6 +64,13 @@ parser.add_argument(
     help="if you have a GPU use 'cuda', otherwise 'cpu'",
 )
 
+parser.add_argument(
+    "--prompt",
+    dest="prompt",
+    default="",
+    help="Initial prompt for transcription",
+)
+
 args = parser.parse_args()
 
 if args.stemming:
@@ -104,6 +111,7 @@ if args.batch_size != 0:
         mtypes[args.device],
         args.suppress_numerals,
         args.device,
+        args.prompt,
     )
 else:
     from transcription_helpers import transcribe
@@ -115,6 +123,7 @@ else:
         mtypes[args.device],
         args.suppress_numerals,
         args.device,
+        args.prompt,
     )
 
 if language in wav2vec2_langs:

--- a/transcription_helpers.py
+++ b/transcription_helpers.py
@@ -8,6 +8,7 @@ def transcribe(
     compute_dtype: str,
     suppress_numerals: bool,
     device: str,
+    initial_prompt: str,
 ):
     from faster_whisper import WhisperModel
     from helpers import find_numeral_symbol_tokens, wav2vec2_langs
@@ -38,6 +39,7 @@ def transcribe(
         word_timestamps=word_timestamps,  # TODO: disable this if the language is supported by wav2vec2
         suppress_tokens=numeral_symbol_tokens,
         vad_filter=True,
+        initial_prompt=initial_prompt,
     )
     whisper_results = []
     for segment in segments:
@@ -56,6 +58,7 @@ def transcribe_batched(
     compute_dtype: str,
     suppress_numerals: bool,
     device: str,
+    initial_prompt: str,
 ):
     import whisperx
 
@@ -64,7 +67,7 @@ def transcribe_batched(
         model_name,
         device,
         compute_type=compute_dtype,
-        asr_options={"suppress_numerals": suppress_numerals},
+        asr_options={"suppress_numerals": suppress_numerals, "initial_prompt" : initial_prompt},
     )
     audio = whisperx.load_audio(audio_file)
     result = whisper_model.transcribe(audio, language=language, batch_size=batch_size)


### PR DESCRIPTION
Adds "prompt" argument to diarize.py and diarize_parallel.py args parser.
Adds passing initial_prompt to batched and non-batched models in transcribe functions.