### PR TITLE
fix(language): missing language parameter

### DIFF
--- a/transcription_helpers.py
+++ b/transcription_helpers.py
@@ -63,6 +63,7 @@ def transcribe_batched(
     whisper_model = whisperx.load_model(
         model_name,
         device,
+        language=language,
         compute_type=compute_dtype,
         asr_options={"suppress_numerals": suppress_numerals},
     )


### PR DESCRIPTION
The problem: If the audio has very long rings in the very beginning of the file, it miss the language parameter and try to detect the language automatically.

After the analysis fo the source code I found that you missed the language parameter in the whisper.load_model().


