### PR TITLE
Update requirements.txt so faster-whisper==1.0.0 is used

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 wget
 nemo_toolkit[asr]==1.22.0
-git+https://github.com/m-bain/whisperX.git@d6562c26da467ca49866a4173c0e723f3837f367
+git+https://github.com/m-bain/whisperX.git
 git+https://github.com/facebookresearch/demucs#egg=demucs
 deepmultilingualpunctuation


### PR DESCRIPTION
The whisperx version listed in requirements.txt is pulling faster-whisper v0.10.0 instead of the needed v1.0.0 causing whisper-diarization to fail with 

`Traceback (most recent call last):
  File "/whisper-diarization/diarize.py", line 97, in <module>
    whisper_results, language = transcribe_batched(
  File "/whisper-diarization/transcription_helpers.py", line 63, in transcribe_batched
    whisper_model = whisperx.load_model(
  File "/usr/local/lib/python3.10/dist-packages/whisperx/asr.py", line 334, in load_model
    default_asr_options = faster_whisper.transcribe.TranscriptionOptions(**default_asr_options)
TypeError: TranscriptionOptions.__new__() got an unexpected keyword argument 'max_new_tokens'`

Removing the commit version from the whisperx line in requirements.txt resolves the issue.