### PR TITLE
Pin Critical Dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ git+https://github.com/m-bain/whisperX.git@78dcfaab51005aa703ee21375f81ed31bc248
 git+https://github.com/adefossez/demucs.git
 git+https://github.com/oliverguhr/deepmultilingualpunctuation.git
 git+https://github.com/MahmoudAshraf97/ctc-forced-aligner.git
-
+transformers==4.38.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ git+https://github.com/adefossez/demucs.git
 git+https://github.com/oliverguhr/deepmultilingualpunctuation.git
 git+https://github.com/MahmoudAshraf97/ctc-forced-aligner.git
 transformers==4.38.2
+huggingface-hub==0.20.3


### PR DESCRIPTION
This PR addresses the issue of dependency resolution and version compatibility, specifically focusing on `transformers` and `huggingface-hub`. By pinning these critical dependencies to specific versions, we aim to improve the stability and reproducibility of the project setup.

## Changes
- Added `transformers==4.38.2` to requirements.txt
- Added `huggingface-hub==0.20.3` to requirements.txt

## Motivation
Recent issues (#182 and #202) have highlighted problems with dependency resolution, particularly related to the `huggingface-hub` package. By explicitly specifying versions for both `transformers` and `huggingface-hub`, we can ensure that all users are working with compatible versions of these critical dependencies.

## Benefits
- Improves reproducibility of the development environment
- Reduces "guess work" during dependency resolution
- Helps prevent issues caused by incompatible package versions

## Testing
I have tested this configuration and confirmed that it resolves the `ModelFilter` import error previously encountered.

## Notes
- This is a first step towards more comprehensive dependency management. Future improvements could include using tools like pip-tools, Poetry, or Pipenv for even better dependency control.
- We may need to periodically update these pinned versions as new releases become available and are tested with our project.

## Related Issues
Relates #182
Relates #202

Please review and let me know if any further changes or testing are needed.