### PR TITLE
new nemo requires ipython

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 wget
+ipython
 nemo_toolkit[asr]>=2.dev
 git+https://github.com/m-bain/whisperX.git@78dcfaab51005aa703ee21375f81ed31bc248560
 git+https://github.com/adefossez/demucs.git
 git+https://github.com/oliverguhr/deepmultilingualpunctuation.git
 git+https://github.com/MahmoudAshraf97/ctc-forced-aligner.git
-


### PR DESCRIPTION
You'll get module not ipython not found if you try to use the 2.0 nemo version