### PR TITLE
Pass device to demucs calls to ensure correct device is used

### DIFF
--- a/Whisper_Transcription_+_NeMo_Diarization.ipynb
+++ b/Whisper_Transcription_+_NeMo_Diarization.ipynb
@@ -765,7 +765,7 @@
     "    # Isolate vocals from the rest of the audio\n",
     "\n",
     "    return_code = os.system(\n",
-    "        f'python -m demucs.separate -n htdemucs --two-stems=vocals \"{audio_path}\" -o \"temp_outputs\"'\n",
+    "        f'python -m demucs.separate -n htdemucs --two-stems=vocals \"{audio_path}\" -o \"temp_outputs\" --device \"{device}\"'\n",
     "    )\n",
     "\n",
     "    if return_code != 0:\n",

--- a/diarize.py
+++ b/diarize.py
@@ -96,7 +96,7 @@ if args.stemming:
     # Isolate vocals from the rest of the audio
 
     return_code = os.system(
-        f'python -m demucs.separate -n htdemucs --two-stems=vocals "{args.audio}" -o temp_outputs'
+        f'python -m demucs.separate -n htdemucs --two-stems=vocals "{args.audio}" -o temp_outputs --device "{args.device}"'
     )
 
     if return_code != 0:

--- a/diarize_parallel.py
+++ b/diarize_parallel.py
@@ -94,7 +94,7 @@ if args.stemming:
     # Isolate vocals from the rest of the audio
 
     return_code = os.system(
-        f'python -m demucs.separate -n htdemucs --two-stems=vocals "{args.audio}" -o temp_outputs'
+        f'python -m demucs.separate -n htdemucs --two-stems=vocals "{args.audio}" -o temp_outputs --device "{args.device}"'
     )
 
     if return_code != 0:


### PR DESCRIPTION
Currently, the calls to demucs do not specify the device to be used, allowing demucs to decide the device itself. This PR modifies the code to ensure that the device used by the rest of whisper-diarization is passed to demucs.

This bug affects Mac users because demucs attempts to use the MPS backend regardless of the device set at the command line. However, the MPS backend is incompatible with demucs, resulting in the following error:

```
NotImplementedError: Output channels > 65536 not supported at the MPS device. As a temporary fix, you can set the environment variable `PYTORCH_ENABLE_MPS_FALLBACK=1` to use the CPU as a fallback for this op. WARNING: this will be slower than running natively on MPS.
```

The changes in this PR pass the default device of `cpu` through to demucs, resolving the error.