### PR TITLE
Change temp_outputs to unique temp folder with pid

### DIFF
--- a/diarize.py
+++ b/diarize.py
@@ -35,6 +35,10 @@ from helpers import (
 
 mtypes = {"cpu": "int8", "cuda": "float16"}
 
+pidInt = os.getpid()
+pidStr = str(pidInt)
+temp_outputs_dir = f"temp_outputs_{pidStr}"
+
 # Initialize parser
 parser = argparse.ArgumentParser()
 parser.add_argument(
@@ -96,7 +100,7 @@ if args.stemming:
     # Isolate vocals from the rest of the audio
 
     return_code = os.system(
-        f'python -m demucs.separate -n htdemucs --two-stems=vocals "{args.audio}" -o temp_outputs --device "{args.device}"'
+        f'python -m demucs.separate -n htdemucs --two-stems=vocals "{args.audio}" -o "{temp_outputs_dir}" --device "{args.device}"'
     )
 
     if return_code != 0:
@@ -107,7 +111,7 @@ if args.stemming:
         vocal_target = args.audio
     else:
         vocal_target = os.path.join(
-            "temp_outputs",
+            temp_outputs_dir,
             "htdemucs",
             os.path.splitext(os.path.basename(args.audio))[0],
             "vocals.wav",
@@ -186,7 +190,7 @@ word_timestamps = postprocess_results(text_starred, spans, stride, scores)
 
 # convert audio to mono for NeMo combatibility
 ROOT = os.getcwd()
-temp_path = os.path.join(ROOT, "temp_outputs")
+temp_path = os.path.join(ROOT, temp_outputs_dir)
 os.makedirs(temp_path, exist_ok=True)
 torchaudio.save(
     os.path.join(temp_path, "mono_file.wav"),

--- a/diarize_parallel.py
+++ b/diarize_parallel.py
@@ -33,6 +33,10 @@ from helpers import (
 
 mtypes = {"cpu": "int8", "cuda": "float16"}
 
+pidInt = os.getpid()
+pidStr = str(pidInt)
+temp_outputs_dir = f"temp_outputs_{pidStr}"
+
 # Initialize parser
 parser = argparse.ArgumentParser()
 parser.add_argument(
@@ -94,7 +98,7 @@ if args.stemming:
     # Isolate vocals from the rest of the audio
 
     return_code = os.system(
-        f'python -m demucs.separate -n htdemucs --two-stems=vocals "{args.audio}" -o temp_outputs --device "{args.device}"'
+        f'python -m demucs.separate -n htdemucs --two-stems=vocals "{args.audio}" -o "{temp_outputs_dir}" --device "{args.device}"'
     )
 
     if return_code != 0:
@@ -105,7 +109,7 @@ if args.stemming:
         vocal_target = args.audio
     else:
         vocal_target = os.path.join(
-            "temp_outputs",
+            temp_outputs_dir,
             "htdemucs",
             os.path.splitext(os.path.basename(args.audio))[0],
             "vocals.wav",
@@ -196,7 +200,7 @@ assert nemo_return_code == 0, (
 )
 
 ROOT = os.getcwd()
-temp_path = os.path.join(ROOT, "temp_outputs")
+temp_path = os.path.join(ROOT, temp_outputs_dir)
 
 speaker_ts = []
 with open(os.path.join(temp_path, "pred_rttms", "mono_file.rttm"), "r") as f:

--- a/nemo_process.py
+++ b/nemo_process.py
@@ -8,6 +8,10 @@ from pydub import AudioSegment
 
 from helpers import create_config
 
+pidInt = os.getpid()
+pidStr = str(pidInt)
+temp_outputs_dir = f"temp_outputs_{pidStr}"
+
 parser = argparse.ArgumentParser()
 parser.add_argument(
     "-a", "--audio", help="name of the target audio file", required=True
@@ -23,7 +27,7 @@ args = parser.parse_args()
 # convert audio to mono for NeMo combatibility
 sound = AudioSegment.from_file(args.audio).set_channels(1)
 ROOT = os.getcwd()
-temp_path = os.path.join(ROOT, "temp_outputs")
+temp_path = os.path.join(ROOT, temp_outputs_dir)
 os.makedirs(temp_path, exist_ok=True)
 sound.export(os.path.join(temp_path, "mono_file.wav"), format="wav")
 


### PR DESCRIPTION
When running multiple instances of whisper-diarization simultaneously on a single server (either diarize.py or diarize_parallel.py), the "temp_outputs" folder was being overwritten and deleted by processes while other processes were still using it. I added the process id to the temporary folder (Example: temp_outputs_31229), so that it is always unique to the instance running it. This folder is already getting deleted by the last line in both diarize.py and diarize_parallel.py. 