### PR TITLE
Multiple temp folders fix

### DIFF
--- a/diarize_parallel.py
+++ b/diarize_parallel.py
@@ -118,7 +118,7 @@ else:
 
 logging.info("Starting Nemo process with vocal_target: ", vocal_target)
 nemo_process = subprocess.Popen(
-    ["python", "nemo_process.py", "-a", vocal_target, "--device", args.device, "--temp-pid", pid],
+    ["python", "nemo_process.py", "-a", vocal_target, "--device", args.device, "--temp-pid", str(pid)],
     stderr=subprocess.PIPE,
 )
 # Transcribe the audio file

--- a/diarize_parallel.py
+++ b/diarize_parallel.py
@@ -118,7 +118,7 @@ else:
 
 logging.info("Starting Nemo process with vocal_target: ", vocal_target)
 nemo_process = subprocess.Popen(
-    ["python", "nemo_process.py", "-a", vocal_target, "--device", args.device],
+    ["python", "nemo_process.py", "-a", vocal_target, "--device", args.device, "--temp-pid", pid],
     stderr=subprocess.PIPE,
 )
 # Transcribe the audio file

--- a/nemo_process.py
+++ b/nemo_process.py
@@ -8,9 +8,6 @@ from pydub import AudioSegment
 
 from helpers import create_config
 
-pid = os.getpid()
-temp_outputs_dir = f"temp_outputs_{pid}"
-
 parser = argparse.ArgumentParser()
 parser.add_argument(
     "-a", "--audio", help="name of the target audio file", required=True
@@ -21,7 +18,15 @@ parser.add_argument(
     default="cuda" if torch.cuda.is_available() else "cpu",
     help="if you have a GPU use 'cuda', otherwise 'cpu'",
 )
+parser.add_argument(
+    "--temp-pid",
+    type=str,
+    required=True,
+    help="Shared ID for temp directory",
+)
 args = parser.parse_args()
+
+temp_outputs_dir = f"temp_outputs_{args.temp_pid}"
 
 # convert audio to mono for NeMo combatibility
 sound = AudioSegment.from_file(args.audio).set_channels(1)


### PR DESCRIPTION
Fixed the issue where the `diarize_parallel.py` and `nemo_process.py` were creating different temp folders by using their own PIDs. This caused mismatches and missing files. Now, the main script generates the PID once and passes it to the subprocess using --temp-pid, so both scripts use the same temp directory. Also made sure to convert the PID to a string to avoid a type error with subprocess.Popen.