### PR TITLE
Implement new diarization model: Sortformer

### DIFF
--- a/.github/workflows/test_run.yml
+++ b/.github/workflows/test_run.yml
@@ -60,6 +60,10 @@ jobs:
         python -m pip install torch torchaudio --index-url https://download.pytorch.org/whl/cpu
         uv pip install --system -c constraints.txt -r requirements.txt
 
+    - name: Test with sortformer diarizer
+      run: |
+        python diarize.py -a "./tests/assets/test.opus" --whisper-model tiny.en --diarizer sortformer
+
     - name: Test with msdd diarizer
       run: |
         python diarize.py -a "./tests/assets/test.opus" --whisper-model tiny.en --diarizer msdd

--- a/diarization/__init__.py
+++ b/diarization/__init__.py
@@ -1,3 +1,4 @@
 from .msdd.msdd import MSDDDiarizer
+from .sortformer.sortformer import SortformerDiarizer
 
-__all__ = ["MSDDDiarizer"]
+__all__ = ["MSDDDiarizer", "SortformerDiarizer"]

--- a/diarization/msdd/msdd.py
+++ b/diarization/msdd/msdd.py
@@ -48,9 +48,7 @@ class MSDDDiarizer:
                 num_workers=0,
                 verbose=True,
             )
-            self.model.clustering_embedding.clus_diar_model._diarizer_params.out_dir = (
-                temp_path
-            )
+            self.model.clustering_embedding.clus_diar_model._diarizer_params.out_dir = temp_path
             self.model.clustering_embedding.clus_diar_model._diarizer_params.manifest_filepath = (
                 manifest_path
             )
@@ -74,18 +72,14 @@ class MSDDDiarizer:
 
 
 def create_config():
-    config = OmegaConf.load(
-        os.path.join(os.path.dirname(__file__), "diar_infer_telephonic.yaml")
-    )
+    config = OmegaConf.load(os.path.join(os.path.dirname(__file__), "diar_infer_telephonic.yaml"))
     pretrained_vad = "vad_multilingual_marblenet"
     pretrained_speaker_model = "titanet_large"
 
     config.diarizer.out_dir = None
     config.diarizer.manifest_filepath = None
     config.diarizer.speaker_embeddings.model_path = pretrained_speaker_model
-    config.diarizer.oracle_vad = (
-        False  # compute VAD provided with model_path to vad config
-    )
+    config.diarizer.oracle_vad = False  # compute VAD provided with model_path to vad config
     config.diarizer.clustering.parameters.oracle_num_speakers = False
 
     # Here, we use our in-house pretrained NeMo VAD model

--- a/diarization/msdd/msdd.py
+++ b/diarization/msdd/msdd.py
@@ -48,7 +48,9 @@ class MSDDDiarizer:
                 num_workers=0,
                 verbose=True,
             )
-            self.model.clustering_embedding.clus_diar_model._diarizer_params.out_dir = temp_path
+            self.model.clustering_embedding.clus_diar_model._diarizer_params.out_dir = (
+                temp_path
+            )
             self.model.clustering_embedding.clus_diar_model._diarizer_params.manifest_filepath = (
                 manifest_path
             )
@@ -72,14 +74,18 @@ class MSDDDiarizer:
 
 
 def create_config():
-    config = OmegaConf.load(os.path.join(os.path.dirname(__file__), "diar_infer_telephonic.yaml"))
+    config = OmegaConf.load(
+        os.path.join(os.path.dirname(__file__), "diar_infer_telephonic.yaml")
+    )
     pretrained_vad = "vad_multilingual_marblenet"
     pretrained_speaker_model = "titanet_large"
 
     config.diarizer.out_dir = None
     config.diarizer.manifest_filepath = None
     config.diarizer.speaker_embeddings.model_path = pretrained_speaker_model
-    config.diarizer.oracle_vad = False  # compute VAD provided with model_path to vad config
+    config.diarizer.oracle_vad = (
+        False  # compute VAD provided with model_path to vad config
+    )
     config.diarizer.clustering.parameters.oracle_num_speakers = False
 
     # Here, we use our in-house pretrained NeMo VAD model

--- a/diarization/sortformer/sortformer.py
+++ b/diarization/sortformer/sortformer.py
@@ -35,12 +35,12 @@ class SortformerDiarizer:
             )
             processed_signal = processed_signal[:, :, : processed_signal_length.max()]
 
-            if self.model.streaming_mode:
-                preds = self.model.forward_streaming(
-                    processed_signal, processed_signal_length
-                )
-                preds = preds.cpu()
+            preds = self.model.forward_streaming(
+                processed_signal, processed_signal_length
+            )
+            preds = preds.cpu()
 
+        # TODO: make this tunable
         diarize_cfg = DiarizeConfig(
             postprocessing_params={
                 "onset": 0.5,

--- a/diarization/sortformer/sortformer.py
+++ b/diarization/sortformer/sortformer.py
@@ -1,0 +1,82 @@
+from warnings import warn
+
+import torch
+
+from nemo.collections.asr.models import SortformerEncLabelModel
+from nemo.collections.asr.parts.mixins.diarization import DiarizeConfig
+
+
+class SortformerDiarizer:
+    def __init__(self, device):
+        self.model: SortformerEncLabelModel = SortformerEncLabelModel.from_pretrained(
+            "nvidia/diar_streaming_sortformer_4spk-v2", map_location=device
+        )
+
+        self.model.sortformer_modules.chunk_len = 340
+        self.model.sortformer_modules.chunk_right_context = 40
+        self.model.sortformer_modules.fifo_len = 40
+        self.model.sortformer_modules.spkcache_update_period = 300
+        self.model.sortformer_modules.spkcache_len = 188
+        self.model.sortformer_modules._check_streaming_parameters()
+
+        warn(
+            "Sortformer supports maximum of 4 speakers only, "
+            "please use MSDD if your audio has more than 4 speakers",
+            Warning,
+        )
+
+        self.model.eval()
+
+    def diarize(self, audio: torch.Tensor):
+        with torch.inference_mode():
+            processed_signal, processed_signal_length = self.model.process_signal(
+                audio_signal=audio,
+                audio_signal_length=torch.tensor([audio.shape[-1]]),
+            )
+            processed_signal = processed_signal[:, :, : processed_signal_length.max()]
+
+            if self.model.streaming_mode:
+                preds = self.model.forward_streaming(
+                    processed_signal, processed_signal_length
+                )
+                preds = preds.cpu()
+
+        diarize_cfg = DiarizeConfig(
+            postprocessing_params={
+                "onset": 0.5,
+                "offset": 0.5,
+                "pad_onset": 0.0,
+                "pad_offset": 0.0,
+                "min_duration_on": 0.0,
+                "min_duration_off": 0.0,
+            }
+        )
+
+        audio_rttm_map_dict = {
+            "audio": {
+                "uniq_id": "audio",
+                "audio_filepath": "tensor_audio",
+                "offset": 0.0,
+                "duration": None,
+                "text": "-",
+                "label": "infer",
+            }
+        }
+
+        self.model._diarize_audio_rttm_map = audio_rttm_map_dict
+        uniq_ids = list(self.model._diarize_audio_rttm_map.keys())
+        processed_outputs = self.model._diarize_output_processing(
+            preds, uniq_ids, diarize_cfg
+        )
+        self.model._diarize_audio_rttm_map = {}
+
+        labels = []
+        for label in processed_outputs[0]:
+            start, end, speaker = label.split()
+            start, end = float(start), float(end)
+            start, end = int(start * 1000), int(end * 1000)
+            labels.append((start, end, int(speaker.split("_")[1])))
+
+        labels = sorted(labels, key=lambda x: x[0])
+
+        return labels

--- a/diarization/sortformer/sortformer.py
+++ b/diarization/sortformer/sortformer.py
@@ -35,9 +35,7 @@ class SortformerDiarizer:
             )
             processed_signal = processed_signal[:, :, : processed_signal_length.max()]
 
-            preds = self.model.forward_streaming(
-                processed_signal, processed_signal_length
-            )
+            preds = self.model.forward_streaming(processed_signal, processed_signal_length)
             preds = preds.cpu()
 
         # TODO: make this tunable
@@ -65,9 +63,7 @@ class SortformerDiarizer:
 
         self.model._diarize_audio_rttm_map = audio_rttm_map_dict
         uniq_ids = list(self.model._diarize_audio_rttm_map.keys())
-        processed_outputs = self.model._diarize_output_processing(
-            preds, uniq_ids, diarize_cfg
-        )
+        processed_outputs = self.model._diarize_output_processing(preds, uniq_ids, diarize_cfg)
         self.model._diarize_audio_rttm_map = {}
 
         labels = []

--- a/diarize.py
+++ b/diarize.py
@@ -89,7 +89,7 @@ parser.add_argument(
 parser.add_argument(
     "--diarizer",
     default="msdd",
-    choices=["msdd"],
+    choices=["msdd", "sortformer"],
     help="Choose the diarization model to use",
 )
 
@@ -188,6 +188,11 @@ if args.diarizer == "msdd":
     from diarization import MSDDDiarizer
 
     diarizer_model = MSDDDiarizer(device=args.device)
+
+elif args.diarizer == "sortformer":
+    from diarization import SortformerDiarizer
+
+    diarizer_model = SortformerDiarizer(device=args.device)
 
 speaker_ts = diarizer_model.diarize(torch.from_numpy(audio_waveform).unsqueeze(0))
 del diarizer_model

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-nemo_toolkit[asr]>=2.3.0
+nemo_toolkit[asr]>=2.5.0rc0
 nltk
 faster-whisper>=1.1.0
 git+https://github.com/MahmoudAshraf97/demucs.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-nemo_toolkit[asr]>=2.5.0rc0
+nemo_toolkit[asr]>=2.5.0
 nltk
 faster-whisper>=1.1.0
 git+https://github.com/MahmoudAshraf97/demucs.git


### PR DESCRIPTION
This a new diarization model that was released by nvidia, the comparison between the two models in DER % is at the following table:


Model | Size | DH3 nSpk ≤ 4 | CALLHOME-part2 nSpk = 2 | CALLHOME-part2 nSpk = 3 | CALLHOME-part2 nSpk = 4 | CH109 nSpk = 2
-- | -- | -- | -- | -- | -- | --
MSDD | 31.1M | 29.40 | 11.41 | 16.45 | 19.49 | 8.24
Sortformer | 123M | 14.63 | 6.27 | 10.27 | 12.30 | 5.03

Although sortformer is 4 times larger, it still runs much faster and has tunable parameters that can be customized for each domain, the only drawback is that it only supports up to 4 speakers

References:
https://arxiv.org/abs/2409.06656v3
https://arxiv.org/abs/2507.18446
https://huggingface.co/nvidia/diar_streaming_sortformer_4spk-v2

to test the new model, checkout this branch and pass `--diarizer sortformer` to `diarize.py`