### PR TITLE
Add megatron-core and torchcodec to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ faster-whisper>=1.1.0
 git+https://github.com/MahmoudAshraf97/demucs.git
 git+https://github.com/oliverguhr/deepmultilingualpunctuation.git
 git+https://github.com/MahmoudAshraf97/ctc-forced-aligner.git
+megatron-core
+torchcodec


### PR DESCRIPTION
When running this on my Apple Silicon Mac, I needed to install `megatron-core` and `torchcodec` to get everything to work. 

Feel free to close this PR if there's some reason not to add these. Maybe there's a reason for these not to be included, but I figured I'd PR what i had, in case it was helpful to anyone. 

Thanks for the repo, worked great for my use case. 