### PR TITLE
Txt timestamps

### DIFF
--- a/diarize.py
+++ b/diarize.py
@@ -35,6 +35,10 @@ from helpers import (
 
 mtypes = {"cpu": "int8", "cuda": "float16"}
 
+pidInt = os.getpid()
+pidStr = str(pidInt)
+temp_outputs_dir = f"temp_outputs_{pidStr}"
+
 # Initialize parser
 parser = argparse.ArgumentParser()
 parser.add_argument(
@@ -96,7 +100,7 @@ if args.stemming:
     # Isolate vocals from the rest of the audio
 
     return_code = os.system(
-        f'python -m demucs.separate -n htdemucs --two-stems=vocals "{args.audio}" -o temp_outputs --device "{args.device}"'
+        f'python -m demucs.separate -n htdemucs --two-stems=vocals "{args.audio}" -o "{temp_outputs_dir}" --device "{args.device}"'
     )
 
     if return_code != 0:
@@ -107,7 +111,7 @@ if args.stemming:
         vocal_target = args.audio
     else:
         vocal_target = os.path.join(
-            "temp_outputs",
+            temp_outputs_dir,
             "htdemucs",
             os.path.splitext(os.path.basename(args.audio))[0],
             "vocals.wav",
@@ -186,7 +190,7 @@ word_timestamps = postprocess_results(text_starred, spans, stride, scores)
 
 # convert audio to mono for NeMo combatibility
 ROOT = os.getcwd()
-temp_path = os.path.join(ROOT, "temp_outputs")
+temp_path = os.path.join(ROOT, temp_outputs_dir)
 os.makedirs(temp_path, exist_ok=True)
 torchaudio.save(
     os.path.join(temp_path, "mono_file.wav"),

--- a/diarize.py
+++ b/diarize.py
@@ -35,9 +35,8 @@ from helpers import (
 
 mtypes = {"cpu": "int8", "cuda": "float16"}
 
-pidInt = os.getpid()
-pidStr = str(pidInt)
-temp_outputs_dir = f"temp_outputs_{pidStr}"
+pid = os.getpid()
+temp_outputs_dir = f"temp_outputs_{pid}"
 
 # Initialize parser
 parser = argparse.ArgumentParser()

--- a/diarize.py
+++ b/diarize.py
@@ -25,6 +25,7 @@ from helpers import (
     get_realigned_ws_mapping_with_punctuation,
     get_sentences_speaker_mapping,
     get_speaker_aware_transcript,
+    get_timestamped_speaker_aware_transcript,
     get_words_speaker_mapping,
     langs_to_iso,
     process_language_arg,
@@ -90,6 +91,14 @@ parser.add_argument(
     dest="device",
     default="cuda" if torch.cuda.is_available() else "cpu",
     help="if you have a GPU use 'cuda', otherwise 'cpu'",
+)
+
+parser.add_argument(
+    "--text-with-timestamps",
+    type=int,
+    dest="text_with_timestamps",
+    default=0,
+    help="Whether to include word-level timestamps in the output text file (1 for yes, 0 for no)",
 )
 
 args = parser.parse_args()
@@ -256,7 +265,10 @@ wsm = get_realigned_ws_mapping_with_punctuation(wsm)
 ssm = get_sentences_speaker_mapping(wsm, speaker_ts)
 
 with open(f"{os.path.splitext(args.audio)[0]}.txt", "w", encoding="utf-8-sig") as f:
-    get_speaker_aware_transcript(ssm, f)
+    if args.text_with_timestamps:
+        get_timestamped_speaker_aware_transcript(ssm, f)
+    else:
+        get_speaker_aware_transcript(ssm, f)
 
 with open(f"{os.path.splitext(args.audio)[0]}.srt", "w", encoding="utf-8-sig") as srt:
     write_srt(ssm, srt)

--- a/diarize_parallel.py
+++ b/diarize_parallel.py
@@ -33,6 +33,10 @@ from helpers import (
 
 mtypes = {"cpu": "int8", "cuda": "float16"}
 
+pidInt = os.getpid()
+pidStr = str(pidInt)
+temp_outputs_dir = f"temp_outputs_{pidStr}"
+
 # Initialize parser
 parser = argparse.ArgumentParser()
 parser.add_argument(
@@ -94,7 +98,7 @@ if args.stemming:
     # Isolate vocals from the rest of the audio
 
     return_code = os.system(
-        f'python -m demucs.separate -n htdemucs --two-stems=vocals "{args.audio}" -o temp_outputs --device "{args.device}"'
+        f'python -m demucs.separate -n htdemucs --two-stems=vocals "{args.audio}" -o "{temp_outputs_dir}" --device "{args.device}"'
     )
 
     if return_code != 0:
@@ -105,7 +109,7 @@ if args.stemming:
         vocal_target = args.audio
     else:
         vocal_target = os.path.join(
-            "temp_outputs",
+            temp_outputs_dir,
             "htdemucs",
             os.path.splitext(os.path.basename(args.audio))[0],
             "vocals.wav",
@@ -196,7 +200,7 @@ assert nemo_return_code == 0, (
 )
 
 ROOT = os.getcwd()
-temp_path = os.path.join(ROOT, "temp_outputs")
+temp_path = os.path.join(ROOT, temp_outputs_dir)
 
 speaker_ts = []
 with open(os.path.join(temp_path, "pred_rttms", "mono_file.rttm"), "r") as f:

--- a/diarize_parallel.py
+++ b/diarize_parallel.py
@@ -33,9 +33,8 @@ from helpers import (
 
 mtypes = {"cpu": "int8", "cuda": "float16"}
 
-pidInt = os.getpid()
-pidStr = str(pidInt)
-temp_outputs_dir = f"temp_outputs_{pidStr}"
+pid = os.getpid()
+temp_outputs_dir = f"temp_outputs_{pid}"
 
 # Initialize parser
 parser = argparse.ArgumentParser()

--- a/helpers.py
+++ b/helpers.py
@@ -477,6 +477,26 @@ def get_speaker_aware_transcript(sentences_speaker_mapping, f):
         f.write(sentence + " ")
 
 
+def get_timestamped_speaker_aware_transcript(sentences_speaker_mapping, f):
+    start_time = format_timestamp(sentences_speaker_mapping[0]['start_time'], always_include_hours=True, decimal_marker=',')
+    f.write(f"{start_time} ")
+    previous_speaker = sentences_speaker_mapping[0]["speaker"]
+    f.write(f"\n{previous_speaker}: ")
+
+    for sentence_dict in sentences_speaker_mapping:
+        speaker = sentence_dict["speaker"]
+        sentence = sentence_dict["text"]
+        start_time = format_timestamp(sentence_dict['start_time'], always_include_hours=True, decimal_marker=',')
+
+        # If this speaker doesn't match the previous one, start a new paragraph
+        if speaker != previous_speaker:
+            f.write(f"\n\n{start_time} ")
+            f.write(f"\n{speaker}: ")
+            previous_speaker = speaker
+
+        # Write the current sentence with timestamps
+        f.write(f"{sentence} ")
+
 def format_timestamp(
     milliseconds: float, always_include_hours: bool = False, decimal_marker: str = "."
 ):

--- a/nemo_process.py
+++ b/nemo_process.py
@@ -8,6 +8,10 @@ from pydub import AudioSegment
 
 from helpers import create_config
 
+pidInt = os.getpid()
+pidStr = str(pidInt)
+temp_outputs_dir = f"temp_outputs_{pidStr}"
+
 parser = argparse.ArgumentParser()
 parser.add_argument(
     "-a", "--audio", help="name of the target audio file", required=True
@@ -23,7 +27,7 @@ args = parser.parse_args()
 # convert audio to mono for NeMo combatibility
 sound = AudioSegment.from_file(args.audio).set_channels(1)
 ROOT = os.getcwd()
-temp_path = os.path.join(ROOT, "temp_outputs")
+temp_path = os.path.join(ROOT, temp_outputs_dir)
 os.makedirs(temp_path, exist_ok=True)
 sound.export(os.path.join(temp_path, "mono_file.wav"), format="wav")
 

--- a/nemo_process.py
+++ b/nemo_process.py
@@ -8,9 +8,8 @@ from pydub import AudioSegment
 
 from helpers import create_config
 
-pidInt = os.getpid()
-pidStr = str(pidInt)
-temp_outputs_dir = f"temp_outputs_{pidStr}"
+pid = os.getpid()
+temp_outputs_dir = f"temp_outputs_{pid}"
 
 parser = argparse.ArgumentParser()
 parser.add_argument(


### PR DESCRIPTION
The change here is to add a command line flag which optionally adds the starting timestamps to the .txt formatted output. 

--text-with-timestamps 1 
     (adds the starting timestamp)

--text-with-timestamps 0 
     (omits the starting timestamp, same as leaving the flag off, which is the default and previous txt format)