### PR TITLE
Option to add timestamps to txt output

### DIFF
--- a/diarize.py
+++ b/diarize.py
@@ -22,6 +22,7 @@ from helpers import (
     get_realigned_ws_mapping_with_punctuation,
     get_sentences_speaker_mapping,
     get_speaker_aware_transcript,
+    get_timestamped_speaker_aware_transcript,
     get_words_speaker_mapping,
     langs_to_iso,
     process_language_arg,
@@ -96,6 +97,12 @@ parser.add_argument(
     default="msdd",
     choices=["msdd"],
     help="Choose the diarization model to use",
+)
+parser.add_argument(
+    "--txt-timestamps",
+    action="store_true",
+    dest="txt_timestamps",
+    help="Whether to include word-level timestamps in the output text file (1 for yes, 0 for no)"
 )
 
 args = parser.parse_args()
@@ -239,7 +246,10 @@ wsm = get_realigned_ws_mapping_with_punctuation(wsm)
 ssm = get_sentences_speaker_mapping(wsm, speaker_ts)
 
 with open(f"{os.path.splitext(args.audio)[0]}.txt", "w", encoding="utf-8-sig") as f:
-    get_speaker_aware_transcript(ssm, f)
+    if args.txt_timestamps:
+        get_timestamped_speaker_aware_transcript(ssm, f)
+    else:
+        get_speaker_aware_transcript(ssm, f)
 
 with open(f"{os.path.splitext(args.audio)[0]}.srt", "w", encoding="utf-8-sig") as srt:
     write_srt(ssm, srt)

--- a/helpers.py
+++ b/helpers.py
@@ -418,6 +418,28 @@ def get_speaker_aware_transcript(sentences_speaker_mapping, f):
         # No matter what, write the current sentence
         f.write(sentence + " ")
 
+def get_timestamped_speaker_aware_transcript(sentences_speaker_mapping, f):
+    if not sentences_speaker_mapping:
+        return
+    
+    previous_speaker = None
+
+    for sentence_dict in sentences_speaker_mapping:
+        speaker = sentence_dict["speaker"]
+        sentence = sentence_dict["text"]
+        start_time = format_timestamp(sentence_dict['start_time'], always_include_hours=True, decimal_marker=',')
+
+        # If this speaker doesn't match the previous one, start a new paragraph
+        if speaker != previous_speaker:
+            if previous_speaker is not None:
+                f.write("\n\n")
+            f.write(f"{start_time} ")
+            f.write(f"\n{speaker}: ")
+            previous_speaker = speaker
+
+        # Write the current sentence with timestamps
+        f.write(f"{sentence} ")
+
 
 def format_timestamp(
     milliseconds: float, always_include_hours: bool = True, decimal_marker: str = ","


### PR DESCRIPTION
The change here is to add a command line flag which optionally adds the starting timestamps to the .txt formatted output.

--txt-timestamps 1
(adds the starting timestamp)

--txt-timestamps 0
(omits the starting timestamp, same as leaving the flag off, which is the default and previous txt format)